### PR TITLE
Adiciona instrução de portas gmail no doc entrando_no_ambiente.md

### DIFF
--- a/docs/entrando_no_ambiente.md
+++ b/docs/entrando_no_ambiente.md
@@ -30,7 +30,9 @@ Por fim, a senha da aplicação para seu dispositivo será gerada, como mostra n
 ### Configuração do arquivo .env
 O seu arquivo .env deve se parecer com isso após completar os passos.
 
-![images](./assets/img/image_env.png)
+![env](https://github.com/2023-1-GCES-SIGeD/2021-2-SiGeD-Doc/assets/42985614/7471435d-fb4c-4dd7-a336-b9436733d25e)
+
+No campo "port", é possível utilizar dois tipos de **Porta Gmail SMTP**: _(i)_ porta 587, do tipo TLS e; _(ii)_ porta 465, do tipo SSL.
 
 Após a configuração do arquivo .env, suba o ambiente seguindo o <a href="https://github.com/DITGO/2021-2-SiGeD-Doc/blob/main/docs/subindo_projeto.md">tutorial</a> criado para auxílio.
 


### PR DESCRIPTION
**Descrição da mudança**  
<!-- Descreva de forma clara e concisa sobre a mudança feita. -->
O tópico de **_criar usuário_** no documento _entrando no ambiente_ de desenvolvimento foi alterado. Foi adicionada uma instrução para que no arquivo _.env_ seja especificada uma porta Gmail, que não seja mais deixada em branco no processo de criação de usuário. As portas Gmail que podem ser utilizadas são: 587 ou 465. Esta alteração na instrução pode evitar futuros problemas ao tentar criar um novo usuário. 

**Tipo da mudança**  
<!-- Marque o checkbox correspondente a mudança. -->
- [ ] Correção de bug.
- [ ] Adição de nova fucionalidade.
- [x] Documentação.
- [ ] Outro: <!-- Especifique. -->